### PR TITLE
added "target" attribute support for a tags

### DIFF
--- a/edd-terms-per-product.php
+++ b/edd-terms-per-product.php
@@ -73,7 +73,8 @@ class EDD_Terms_Per_Product {
 		return wp_kses( $data, array(
 			'a' => array(
 				'href' => array(),
-				'title' => array()
+				'title' => array(),
+				'target' => array()
 			),
 			'br' => array(),
 			'em' => array(),


### PR DESCRIPTION
Hi
Is it possible to add “target” field to anchor element? Our terms are quite long, we want to give people short version in checkout and link that would open in a new window, where full terms are written. Currently sanitation removes target=”_blank”…